### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,9 @@
 
 name: .NET Core Desktop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/talhacelikk/CSharp--in-30-Days/security/code-scanning/1](https://github.com/talhacelikk/CSharp--in-30-Days/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to the least privileges necessary. Based on the operations performed in the workflow, the `contents: read` permission is sufficient, as the workflow does not appear to require write access to the repository.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
